### PR TITLE
Improvements to API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-json-path"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Trevor Hilton <trevor.hilton@gmail.com>"]
 edition = "2021"
 description = "Use serde_json_path in the browser"
@@ -26,6 +26,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 # compared to the default allocator's ~10K. It is slower than the default
 # allocator, however.
 wee_alloc = { version = "0.4.5", optional = true }
+serde = "1.0"
 serde_json_path = "0.6.0"
 serde_json = "1.0.93"
 thiserror = "1.0.38"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const obj = {
 
 const path = JsonPath.parse("$.foo.*");
 const nodes = path.query(obj);
-// -> ["bar", "baz"]
+// nodes -> ["bar", "baz"]
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -1,20 +1,37 @@
-# serde-json-path-wasm
+# serde-json-path
 
 ## About
 
-This crate is used to publish the Rust [`serde_json_path`](https://crates.io/crates/serde_json_path) crate into WASM, to be used in a browser.
+This crate is used to publish the JSONPath parsing and query functionality of the Rust [`serde_json_path`](https://crates.io/crates/serde_json_path) crate into WASM, to be used in a browser.
 
 It is used at [serdejsonpath.live](https://serdejsonpath.live).
 
 ## Usage
 
-### Build with `wasm-pack build`
+```javascript
+import { JsonPath } from "serde-json-path";
+
+const obj = {
+  "foo": [
+    "bar",
+    "baz"
+  ]
+};
+
+const path = JsonPath.parse("$.foo.*");
+const nodes = path.query(obj);
+// -> ["bar", "baz"]
+```
+
+## Build
+
+Build with `wasm-pack build`
 
 ```
 wasm-pack build
 ```
 
-### Publish to NPM with `wasm-pack publish`
+Publish to NPM with `wasm-pack publish`
 
 ```
 wasm-pack publish


### PR DESCRIPTION
These changes are meant to improve the API of the WASM package:
* make it more in line with the `serde_json_path` crate by having distinct `parse` and `query` methods
* Use `JsError` type in returns
* JSON compatible serialization is used so that the query results use plain JS Objects instead of `Map`s

The README was updated with a usage example. This bumps to `0.2.0`.