### PR TITLE
Update `serde_json_path` version to 0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-json-path"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Trevor Hilton <trevor.hilton@gmail.com>"]
 edition = "2021"
 description = "Use serde_json_path in the browser"
@@ -27,7 +27,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 # allocator, however.
 wee_alloc = { version = "0.4.5", optional = true }
 serde = "1.0"
-serde_json_path = "0.6.2"
+serde_json_path = "0.6.3"
 serde_json = "1.0.93"
 thiserror = "1.0.38"
 serde-wasm-bindgen = "0.4.5"


### PR DESCRIPTION
Updated the version of the `serde_json_path` dependency to latest 0.6.3.